### PR TITLE
Fix Plugin Executable Name

### DIFF
--- a/Plugins/SwiftPackageListJSONPlugin/SwiftPackageListJSONPlugin.swift
+++ b/Plugins/SwiftPackageListJSONPlugin/SwiftPackageListJSONPlugin.swift
@@ -22,8 +22,6 @@ extension SwiftPackageListJSONPlugin: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
         let projectPath = context.xcodeProject.directory.appending("\(context.xcodeProject.displayName).xcodeproj")
         let executable = try context.tool(named: "SwiftPackageListCommand").path
-            .removingLastComponent()
-            .appending("swift-package-list")
         let outputPath = context.pluginWorkDirectory
         let fileType = "json"
         return [

--- a/Plugins/SwiftPackageListPDFPlugin/SwiftPackageListPDFPlugin.swift
+++ b/Plugins/SwiftPackageListPDFPlugin/SwiftPackageListPDFPlugin.swift
@@ -22,8 +22,6 @@ extension SwiftPackageListPDFPlugin: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
         let projectPath = context.xcodeProject.directory.appending("\(context.xcodeProject.displayName).xcodeproj")
         let executable = try context.tool(named: "SwiftPackageListCommand").path
-            .removingLastComponent()
-            .appending("swift-package-list")
         let outputPath = context.pluginWorkDirectory
         let fileType = "pdf"
         return [

--- a/Plugins/SwiftPackageListPropertyListPlugin/SwiftPackageListPropertyListPlugin.swift
+++ b/Plugins/SwiftPackageListPropertyListPlugin/SwiftPackageListPropertyListPlugin.swift
@@ -22,8 +22,6 @@ extension SwiftPackageListPropertyListPlugin: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
         let projectPath = context.xcodeProject.directory.appending("\(context.xcodeProject.displayName).xcodeproj")
         let executable = try context.tool(named: "SwiftPackageListCommand").path
-            .removingLastComponent()
-            .appending("swift-package-list")
         let outputPath = context.pluginWorkDirectory
         let fileType = "plist"
         return [

--- a/Plugins/SwiftPackageListSettingsBundlePlugin/SwiftPackageListSettingsBundlePlugin.swift
+++ b/Plugins/SwiftPackageListSettingsBundlePlugin/SwiftPackageListSettingsBundlePlugin.swift
@@ -22,8 +22,6 @@ extension SwiftPackageListSettingsBundlePlugin: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
         let projectPath = context.xcodeProject.directory.appending("\(context.xcodeProject.displayName).xcodeproj")
         let executable = try context.tool(named: "SwiftPackageListCommand").path
-            .removingLastComponent()
-            .appending("swift-package-list")
         let outputPath = context.pluginWorkDirectory
         let fileType = "settings-bundle"
         return [


### PR DESCRIPTION
The executable name seems to be named as `SwiftPackageListCommand` when not added locally. Therefore we can remove the name patching.
<img width="1085" alt="Screenshot 2023-05-29 at 00 43 20" src="https://github.com/FelixHerrmann/swift-package-list/assets/42500484/163c34ba-9085-4a7c-80fc-107b26e209d4">
