### PR TITLE
Fix SwiftPackageIndex DocC failing for Objective-C target

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,5 +4,4 @@ builder:
     - scheme: Libraries
       documentation_targets:
         - SwiftPackageList
-        - SwiftPackageListObjc
         - SwiftPackageListUI


### PR DESCRIPTION
As of yet only Swift targets seems to be allowed for DocC documentation builds: https://swiftpackageindex.com/builds/159B1828-4A97-4D76-BE70-FB75C58B4574