### PR TITLE
Fix Plugin Derived Data Path

### DIFF
--- a/Plugins/SwiftPackageListJSONPlugin/SwiftPackageListJSONPlugin.swift
+++ b/Plugins/SwiftPackageListJSONPlugin/SwiftPackageListJSONPlugin.swift
@@ -24,14 +24,35 @@ extension SwiftPackageListJSONPlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "json"
+        let derivedDataPath = context.derivedDataDirectory
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
                 executable: executable,
-                arguments: ["generate", projectPath, "--output-path", outputPath, "--file-type", fileType, "--requires-license"],
+                arguments: [
+                    "generate",
+                    projectPath,
+                    "--derived-data-path", derivedDataPath,
+                    "--output-path", outputPath,
+                    "--file-type", fileType,
+                    "--requires-license"
+                ],
                 outputFiles: [outputPath.appending("package-list.json")]
             )
         ]
+    }
+}
+
+extension XcodePluginContext {
+    var derivedDataDirectory: Path {
+        var path = pluginWorkDirectory
+        while path.lastComponent != "DerivedData" {
+            guard path.string != "/" else {
+                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+            }
+            path = path.removingLastComponent()
+        }
+        return path
     }
 }
 #endif

--- a/Plugins/SwiftPackageListPDFPlugin/SwiftPackageListPDFPlugin.swift
+++ b/Plugins/SwiftPackageListPDFPlugin/SwiftPackageListPDFPlugin.swift
@@ -24,14 +24,35 @@ extension SwiftPackageListPDFPlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "pdf"
+        let derivedDataPath = context.derivedDataDirectory
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
                 executable: executable,
-                arguments: ["generate", projectPath, "--output-path", outputPath, "--file-type", fileType, "--requires-license"],
+                arguments: [
+                    "generate",
+                    projectPath,
+                    "--derived-data-path", derivedDataPath,
+                    "--output-path", outputPath,
+                    "--file-type", fileType,
+                    "--requires-license"
+                ],
                 outputFiles: [outputPath.appending("Acknowledgements.pdf")]
             )
         ]
+    }
+}
+
+extension XcodePluginContext {
+    var derivedDataDirectory: Path {
+        var path = pluginWorkDirectory
+        while path.lastComponent != "DerivedData" {
+            guard path.string != "/" else {
+                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+            }
+            path = path.removingLastComponent()
+        }
+        return path
     }
 }
 #endif

--- a/Plugins/SwiftPackageListPropertyListPlugin/SwiftPackageListPropertyListPlugin.swift
+++ b/Plugins/SwiftPackageListPropertyListPlugin/SwiftPackageListPropertyListPlugin.swift
@@ -24,14 +24,35 @@ extension SwiftPackageListPropertyListPlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "plist"
+        let derivedDataPath = context.derivedDataDirectory
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
                 executable: executable,
-                arguments: ["generate", projectPath, "--output-path", outputPath, "--file-type", fileType, "--requires-license"],
+                arguments: [
+                    "generate",
+                    projectPath,
+                    "--derived-data-path", derivedDataPath,
+                    "--output-path", outputPath,
+                    "--file-type", fileType,
+                    "--requires-license"
+                ],
                 outputFiles: [outputPath.appending("package-list.plist")]
             )
         ]
+    }
+}
+
+extension XcodePluginContext {
+    var derivedDataDirectory: Path {
+        var path = pluginWorkDirectory
+        while path.lastComponent != "DerivedData" {
+            guard path.string != "/" else {
+                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+            }
+            path = path.removingLastComponent()
+        }
+        return path
     }
 }
 #endif

--- a/Plugins/SwiftPackageListSettingsBundlePlugin/SwiftPackageListSettingsBundlePlugin.swift
+++ b/Plugins/SwiftPackageListSettingsBundlePlugin/SwiftPackageListSettingsBundlePlugin.swift
@@ -24,14 +24,35 @@ extension SwiftPackageListSettingsBundlePlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "settings-bundle"
+        let derivedDataPath = context.derivedDataDirectory
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
                 executable: executable,
-                arguments: ["generate", projectPath, "--output-path", outputPath, "--file-type", fileType, "--requires-license"],
+                arguments: [
+                    "generate",
+                    projectPath,
+                    "--derived-data-path", derivedDataPath,
+                    "--output-path", outputPath,
+                    "--file-type", fileType,
+                    "--requires-license"
+                ],
                 outputFiles: [outputPath.appending("Settings.bundle")]
             )
         ]
+    }
+}
+
+extension XcodePluginContext {
+    var derivedDataDirectory: Path {
+        var path = pluginWorkDirectory
+        while path.lastComponent != "DerivedData" {
+            guard path.string != "/" else {
+                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+            }
+            path = path.removingLastComponent()
+        }
+        return path
     }
 }
 #endif


### PR DESCRIPTION
As soon as Xcode does not use the default derived data location all of the plugins fail. This means the plugins cannot be used in Xcode Cloud and many other custom setups.

I fixed that with configuring the `--derived-data-path` argument based on the `XcodePluginContext.pluginWorkDirectory` path which is located inside of Derived Data.