### PR TITLE
Fix info.plist no Permissions

### DIFF
--- a/Plugins/SwiftPackageListJSONPlugin/SwiftPackageListJSONPlugin.swift
+++ b/Plugins/SwiftPackageListJSONPlugin/SwiftPackageListJSONPlugin.swift
@@ -24,7 +24,7 @@ extension SwiftPackageListJSONPlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "json"
-        let derivedDataPath = context.derivedDataDirectory
+        let sourcePackagesPath = try context.sourcePackagesDirectory()
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
@@ -32,7 +32,7 @@ extension SwiftPackageListJSONPlugin: XcodeBuildToolPlugin {
                 arguments: [
                     "generate",
                     projectPath,
-                    "--derived-data-path", derivedDataPath,
+                    "--source-packages-path", sourcePackagesPath,
                     "--output-path", outputPath,
                     "--file-type", fileType,
                     "--requires-license"
@@ -43,12 +43,14 @@ extension SwiftPackageListJSONPlugin: XcodeBuildToolPlugin {
     }
 }
 
+struct SourcePackagesNotFoundError: Error { }
+
 extension XcodePluginContext {
-    var derivedDataDirectory: Path {
+    func sourcePackagesDirectory() throws -> Path {
         var path = pluginWorkDirectory
-        while path.lastComponent != "DerivedData" {
+        while path.lastComponent != "SourcePackages" {
             guard path.string != "/" else {
-                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+                throw SourcePackagesNotFoundError()
             }
             path = path.removingLastComponent()
         }

--- a/Plugins/SwiftPackageListPDFPlugin/SwiftPackageListPDFPlugin.swift
+++ b/Plugins/SwiftPackageListPDFPlugin/SwiftPackageListPDFPlugin.swift
@@ -24,7 +24,7 @@ extension SwiftPackageListPDFPlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "pdf"
-        let derivedDataPath = context.derivedDataDirectory
+        let sourcePackagesPath = try context.sourcePackagesDirectory()
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
@@ -32,7 +32,7 @@ extension SwiftPackageListPDFPlugin: XcodeBuildToolPlugin {
                 arguments: [
                     "generate",
                     projectPath,
-                    "--derived-data-path", derivedDataPath,
+                    "--source-packages-path", sourcePackagesPath,
                     "--output-path", outputPath,
                     "--file-type", fileType,
                     "--requires-license"
@@ -43,12 +43,14 @@ extension SwiftPackageListPDFPlugin: XcodeBuildToolPlugin {
     }
 }
 
+struct SourcePackagesNotFoundError: Error { }
+
 extension XcodePluginContext {
-    var derivedDataDirectory: Path {
+    func sourcePackagesDirectory() throws -> Path {
         var path = pluginWorkDirectory
-        while path.lastComponent != "DerivedData" {
+        while path.lastComponent != "SourcePackages" {
             guard path.string != "/" else {
-                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+                throw SourcePackagesNotFoundError()
             }
             path = path.removingLastComponent()
         }

--- a/Plugins/SwiftPackageListPropertyListPlugin/SwiftPackageListPropertyListPlugin.swift
+++ b/Plugins/SwiftPackageListPropertyListPlugin/SwiftPackageListPropertyListPlugin.swift
@@ -24,7 +24,7 @@ extension SwiftPackageListPropertyListPlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "plist"
-        let derivedDataPath = context.derivedDataDirectory
+        let sourcePackagesPath = try context.sourcePackagesDirectory()
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
@@ -32,7 +32,7 @@ extension SwiftPackageListPropertyListPlugin: XcodeBuildToolPlugin {
                 arguments: [
                     "generate",
                     projectPath,
-                    "--derived-data-path", derivedDataPath,
+                    "--source-packages-path", sourcePackagesPath,
                     "--output-path", outputPath,
                     "--file-type", fileType,
                     "--requires-license"
@@ -43,12 +43,14 @@ extension SwiftPackageListPropertyListPlugin: XcodeBuildToolPlugin {
     }
 }
 
+struct SourcePackagesNotFoundError: Error { }
+
 extension XcodePluginContext {
-    var derivedDataDirectory: Path {
+    func sourcePackagesDirectory() throws -> Path {
         var path = pluginWorkDirectory
-        while path.lastComponent != "DerivedData" {
+        while path.lastComponent != "SourcePackages" {
             guard path.string != "/" else {
-                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+                throw SourcePackagesNotFoundError()
             }
             path = path.removingLastComponent()
         }

--- a/Plugins/SwiftPackageListSettingsBundlePlugin/SwiftPackageListSettingsBundlePlugin.swift
+++ b/Plugins/SwiftPackageListSettingsBundlePlugin/SwiftPackageListSettingsBundlePlugin.swift
@@ -24,7 +24,7 @@ extension SwiftPackageListSettingsBundlePlugin: XcodeBuildToolPlugin {
         let executable = try context.tool(named: "swift-package-list").path
         let outputPath = context.pluginWorkDirectory
         let fileType = "settings-bundle"
-        let derivedDataPath = context.derivedDataDirectory
+        let sourcePackagesPath = try context.sourcePackagesDirectory()
         return [
             .buildCommand(
                 displayName: "SwiftPackageListPlugin",
@@ -32,7 +32,7 @@ extension SwiftPackageListSettingsBundlePlugin: XcodeBuildToolPlugin {
                 arguments: [
                     "generate",
                     projectPath,
-                    "--derived-data-path", derivedDataPath,
+                    "--source-packages-path", sourcePackagesPath,
                     "--output-path", outputPath,
                     "--file-type", fileType,
                     "--requires-license"
@@ -43,12 +43,14 @@ extension SwiftPackageListSettingsBundlePlugin: XcodeBuildToolPlugin {
     }
 }
 
+struct SourcePackagesNotFoundError: Error { }
+
 extension XcodePluginContext {
-    var derivedDataDirectory: Path {
+    func sourcePackagesDirectory() throws -> Path {
         var path = pluginWorkDirectory
-        while path.lastComponent != "DerivedData" {
+        while path.lastComponent != "SourcePackages" {
             guard path.string != "/" else {
-                return Path("\(NSHomeDirectory())/Library/Developer/Xcode/DerivedData")
+                throw SourcePackagesNotFoundError()
             }
             path = path.removingLastComponent()
         }

--- a/Sources/SwiftPackageListCore/File Representations/Project.swift
+++ b/Sources/SwiftPackageListCore/File Representations/Project.swift
@@ -67,10 +67,14 @@ extension Project {
                 options: [.skipsHiddenFiles]
             )
             guard let infoDotPlist = buildFiles.first(where: { $0.lastPathComponent == "info.plist" }) else { continue }
-            let infoPlistData = try Data(contentsOf: infoDotPlist)
-            let infoPlist = try PropertyListDecoder().decode(InfoPlist.self, from: infoPlistData)
-            if infoPlist.workspacePath == fileURL.path {
-                return buildDirectory
+            do {
+                let infoPlistData = try Data(contentsOf: infoDotPlist)
+                let infoPlist = try PropertyListDecoder().decode(InfoPlist.self, from: infoPlistData)
+                if infoPlist.workspacePath == fileURL.path {
+                    return buildDirectory
+                }
+            } catch {
+                print("Warning: Could not open or decode \(infoDotPlist)")
             }
         }
         

--- a/Sources/SwiftPackageListCore/File Representations/Project.swift
+++ b/Sources/SwiftPackageListCore/File Representations/Project.swift
@@ -67,14 +67,10 @@ extension Project {
                 options: [.skipsHiddenFiles]
             )
             guard let infoDotPlist = buildFiles.first(where: { $0.lastPathComponent == "info.plist" }) else { continue }
-            do {
-                let infoPlistData = try Data(contentsOf: infoDotPlist)
-                let infoPlist = try PropertyListDecoder().decode(InfoPlist.self, from: infoPlistData)
-                if infoPlist.workspacePath == fileURL.path {
-                    return buildDirectory
-                }
-            } catch {
-                print("Warning: Could not open or decode \(infoDotPlist)")
+            let infoPlistData = try Data(contentsOf: infoDotPlist)
+            let infoPlist = try PropertyListDecoder().decode(InfoPlist.self, from: infoPlistData)
+            if infoPlist.workspacePath == fileURL.path {
+                return buildDirectory
             }
         }
         


### PR DESCRIPTION
A new error came up in Xcode Cloud after #56: `Error: The file “info.plist” couldn’t be opened.`
I'm not 100% sure why this is happening, I guess it's a permission thing, maybe the runner has other projects in derived data too.

I was able to fix the issue with simply using the SourcePackages path. This is actually a much better solution because the tool has to do less/no more project searching in DerivedData.