### PR TITLE
Add Polish translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ The Settings Bundle and the UI-components are currently localized in the followi
 | German               | de      |
 | Hindi                | hi      |
 | Italian              | it      |
+| Polish               | pl      |
 | Portuguese           | pt      |
 | Russian              | ru      |
 | Spanish              | es      |

--- a/Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator+Language.swift
+++ b/Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator+Language.swift
@@ -17,6 +17,7 @@ extension SettingsBundleGenerator {
         case fr
         case hi
         case it
+        case pl
         case pt
         case ru
         case uk
@@ -60,6 +61,10 @@ extension SettingsBundleGenerator.Language {
         case .it:
             return [
                 .acknowledgements: "Ringraziamenti",
+            ]
+        case .pl:
+            return [
+                .acknowledgements: "Podziękowania",
             ]
         case .pt:
             return [
@@ -119,6 +124,10 @@ extension SettingsBundleGenerator.Language {
         case .it:
             return [
                 .licenses: "Licenze",
+            ]
+        case .pl:
+            return [
+                .licenses: "Licencje",
             ]
         case .pt:
             return [

--- a/Sources/SwiftPackageListUI/Resources/pl.lproj/Localizable.strings
+++ b/Sources/SwiftPackageListUI/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+
+// Navigation bar title of the license list
+"acknowledgments.title" = "Podziękowania";
+
+// Section title for the license list
+"acknowledgments.section-title" = "Licencje";
+
+// Opens the repository in a browser window, only shown on iOS 12 and lower
+"license-text.repository-button-text" = "Repozytorium";


### PR DESCRIPTION
Adds Polish translation to settings bundle generator. Selected the translation to be the same as the one used in Apple's Books app settings.