### PR TITLE
Use .sortedKeys for JSONEncoder, so output is stable

### DIFF
--- a/Sources/SwiftPackageListCore/Output Generation/JSON/JSONGenerator.swift
+++ b/Sources/SwiftPackageListCore/Output Generation/JSON/JSONGenerator.swift
@@ -15,7 +15,7 @@ struct JSONGenerator: OutputGenerator {
     
     private let jsonEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return encoder
     }()
     

--- a/Tests/SwiftPackageListCoreTests/JSONGeneratorTests.swift
+++ b/Tests/SwiftPackageListCoreTests/JSONGeneratorTests.swift
@@ -42,10 +42,10 @@ final class JSONGeneratorTests: XCTestCase {
         let expectedOutput = """
         [
           {
-            "revision" : "xxxx",
             "license" : "MIT",
             "name" : "test",
             "repositoryURL" : "https:\\/\\/github.com\\/test\\/test",
+            "revision" : "xxxx",
             "version" : "1.0.0"
           }
         ]


### PR DESCRIPTION
When using `swift-package-list` as part of our toolchain, JSON output often changes despite the licenses not changing. 

It seems `.prettyPrint` keys aren't sorted, and so the order of the JSON keys can fluctuate. I'd propose using `.sortedKeys` instead, so we can store the json in our git without generating superfluous changes.