### PR TITLE
[ADD] resolving package names from Package file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ In addition to that you can specify the following options:
 | -d, --derived-data-path \<derived-data-path\>       | The path to your DerivedData-folder. (default: ~/Library/Developer/Xcode/DerivedData)                                         |
 | -s, --source-packages-path \<source-packages-path\> | The path to a custom SourcePackages-folder.                                                                                   |
 | --requires-license                                  | Will skip the packages without a license-file.                                                                                |
+| --resolves-packages-names                           | Will try to resolve the package name from the Package.swift file.                                                             |
 | --version                                           | Show the version.                                                                                                             |
 | -h, --help                                          | Show help information.                                                                                                        |
 
@@ -62,6 +63,7 @@ In addition to that you can specify the following options:
 | -f, --file-type \<file-type\>                       | The file type of the generated package-list file. Available options are json, plist, settings-bundle and pdf. (default: json) |
 | -c, --custom-file-name \<custom-file-name\>         | A custom filename to be used instead of the default ones.                                                                     |
 | --requires-license                                  | Will skip the packages without a license-file.                                                                                |
+| --resolves-packages-names                           | Will try to resolve the package name from the Package.swift file.                                                             |
 | --version                                           | Show the version.                                                                                                             |
 | -h, --help                                          | Show help information.                                                                                                        |
 

--- a/Sources/SwiftPackageListCore/File Representations/PackageResolved.swift
+++ b/Sources/SwiftPackageListCore/File Representations/PackageResolved.swift
@@ -74,11 +74,11 @@ extension PackageResolved {
     private func packages(v1: PackageResolved_V1, checkoutsDirectory: URL, requiresLicense: Bool, resolvesPackageNames: Bool) throws -> [Package] {
         return try v1.object.pins.compactMap { pin -> Package? in
             guard let checkoutURL = pin.checkoutURL else { return nil }
-            let name = try extractPackageName(for: checkoutURL, in: checkoutsDirectory, resolvesPackageNames: resolvesPackageNames)
+            let packageName = try extractPackageName(for: checkoutURL, in: checkoutsDirectory, resolvesPackageNames: resolvesPackageNames)
             if let licensePath = try licensePath(for: checkoutURL, in: checkoutsDirectory) {
                 let license = try String(contentsOf: licensePath, encoding: .utf8)
                 return Package(
-                    name: name,
+                    name: packageName,
                     version: pin.state.version,
                     branch: pin.state.branch,
                     revision: pin.state.revision,
@@ -87,7 +87,7 @@ extension PackageResolved {
                 )
             } else if !requiresLicense {
                 return Package(
-                    name: name,
+                    name: packageName,
                     version: pin.state.version,
                     branch: pin.state.branch,
                     revision: pin.state.revision,
@@ -132,11 +132,11 @@ extension PackageResolved {
     private func packages(v2: PackageResolved_V2, checkoutsDirectory: URL, requiresLicense: Bool, resolvesPackageNames: Bool) throws -> [Package] {
         return try v2.pins.compactMap { pin -> Package? in
             guard let checkoutURL = pin.checkoutURL else { return nil }
-            let name = try extractPackageName(for: checkoutURL, in: checkoutsDirectory, resolvesPackageNames: resolvesPackageNames)
+            let packageName = try extractPackageName(for: checkoutURL, in: checkoutsDirectory, resolvesPackageNames: resolvesPackageNames)
             if let licensePath = try licensePath(for: checkoutURL, in: checkoutsDirectory) {
                 let license = try String(contentsOf: licensePath, encoding: .utf8)
                 return Package(
-                    name: name,
+                    name: packageName,
                     version: pin.state.version,
                     branch: pin.state.branch,
                     revision: pin.state.revision,
@@ -145,7 +145,7 @@ extension PackageResolved {
                 )
             } else if !requiresLicense {
                 return Package(
-                    name: name,
+                    name: packageName,
                     version: pin.state.version,
                     branch: pin.state.branch,
                     revision: pin.state.revision,

--- a/Sources/swift-package-list/SwiftPackageList+Generate.swift
+++ b/Sources/swift-package-list/SwiftPackageList+Generate.swift
@@ -50,7 +50,7 @@ extension SwiftPackageList {
             }
             
             let packageResolved = try PackageResolved(at: project.packageResolvedFileURL)
-            let packages = try packageResolved.packages(in: checkoutsDirectory, requiresLicense: options.requiresLicense)
+            let packages = try packageResolved.packages(in: checkoutsDirectory, requiresLicense: options.requiresLicense, resolvesPackageNames: options.resolvesPackageNames)
             
             let outputURL = fileType.outputURL(at: outputPath, customFileName: customFileName)
             let outputGenerator = fileType.outputGenerator(outputURL: outputURL, packages: packages, project: project)

--- a/Sources/swift-package-list/SwiftPackageList+Options.swift
+++ b/Sources/swift-package-list/SwiftPackageList+Options.swift
@@ -21,5 +21,8 @@ extension SwiftPackageList {
         
         @Flag(help: "Will skip the packages without a license-file.")
         var requiresLicense = false
+        
+        @Flag(help: "Will try to resolve the package name from the Package.swift file if true.")
+        var resolvesPackageNames = false
     }
 }

--- a/Sources/swift-package-list/SwiftPackageList+Options.swift
+++ b/Sources/swift-package-list/SwiftPackageList+Options.swift
@@ -22,7 +22,7 @@ extension SwiftPackageList {
         @Flag(help: "Will skip the packages without a license-file.")
         var requiresLicense = false
         
-        @Flag(help: "Will try to resolve the package name from the Package.swift file if true.")
+        @Flag(help: "Will try to resolve the package name from the Package.swift file.")
         var resolvesPackageNames = false
     }
 }

--- a/Sources/swift-package-list/SwiftPackageList+Scan.swift
+++ b/Sources/swift-package-list/SwiftPackageList+Scan.swift
@@ -40,7 +40,7 @@ extension SwiftPackageList {
             }
             
             let packageResolved = try PackageResolved(at: project.packageResolvedFileURL)
-            let packages = try packageResolved.packages(in: checkoutsDirectory, requiresLicense: options.requiresLicense)
+            let packages = try packageResolved.packages(in: checkoutsDirectory, requiresLicense: options.requiresLicense, resolvesPackageNames: options.resolvesPackageNames)
             
             let jsonEncoder = JSONEncoder()
             jsonEncoder.outputFormatting = .prettyPrinted

--- a/Tests/SwiftPackageListCoreTests/PackageResolvedTests.swift
+++ b/Tests/SwiftPackageListCoreTests/PackageResolvedTests.swift
@@ -6,7 +6,9 @@
 //
 
 import XCTest
+
 @testable import SwiftPackageListCore
+@testable import SwiftPackageList
 
 final class PackageResolvedTests: XCTestCase {
     
@@ -55,5 +57,44 @@ final class PackageResolvedTests: XCTestCase {
             XCTAssertTrue(error is RuntimeError)
             XCTAssertEqual((error as? RuntimeError)?.description, "The version of the Package.resolved is not supported")
         }
+    }
+    
+    func testPackagesVersion1WithoutResolvingPackageNames() throws {
+        
+        let output = try generatePackagesOutput(for: "Package_v1", resolvesPackageNames: false)
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(output.first?.name, "swift-package-list")
+    }
+    
+    func testPackagesVersion1ByResolvingPackageNames() throws {
+        
+        let output = try generatePackagesOutput(for: "Package_v1", resolvesPackageNames: true)
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(output.first?.name, "SwiftPackageList")
+    }
+    
+    func testPackagesVersion2WithoutResolvingPackageNames() throws {
+        
+        let output = try generatePackagesOutput(for: "Package_v2", resolvesPackageNames: false)
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(output.first?.name, "swift-package-list")
+    }
+    
+    func testPackagesVersion2ByResolvingPackageNames() throws {
+        
+        let output = try generatePackagesOutput(for: "Package_v2", resolvesPackageNames: true)
+        XCTAssertEqual(output.count, 1)
+        XCTAssertEqual(output.first?.name, "SwiftPackageList")
+    }
+    
+    private func generatePackagesOutput(for packageFileName: String, resolvesPackageNames: Bool) throws -> [Package] {
+        
+        let url = Bundle.module.url(forResource: packageFileName, withExtension: "resolved", subdirectory: "Resources")
+        let unwrappedURL = try XCTUnwrap(url)
+        let packageResolved = try PackageResolved(at: unwrappedURL)
+        let packageFileURL = Bundle.module.url(forResource: "Package", withExtension: "swift", subdirectory: "Resources/swift-package-list")
+        let ressourcesURL = packageFileURL!.deletingLastPathComponent().deletingLastPathComponent()
+        
+        return try packageResolved.packages(in: ressourcesURL, requiresLicense: false, resolvesPackageNames: resolvesPackageNames)
     }
 }

--- a/Tests/SwiftPackageListCoreTests/Resources/swift-package-list/Package.swift
+++ b/Tests/SwiftPackageListCoreTests/Resources/swift-package-list/Package.swift
@@ -1,0 +1,85 @@
+// swift-tools-version:5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftPackageList",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v10_15),
+        .macCatalyst(.v13),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
+    products: [
+        .executable(name: "swift-package-list", targets: ["swift-package-list"]),
+        .plugin(name: "SwiftPackageListJSONPlugin", targets: ["SwiftPackageListJSONPlugin"]),
+        .plugin(name: "SwiftPackageListPropertyListPlugin", targets: ["SwiftPackageListPropertyListPlugin"]),
+        .plugin(name: "SwiftPackageListSettingsBundlePlugin", targets: ["SwiftPackageListSettingsBundlePlugin"]),
+        .plugin(name: "SwiftPackageListPDFPlugin", targets: ["SwiftPackageListPDFPlugin"]),
+        .library(name: "SwiftPackageList", targets: ["SwiftPackageList"]),
+        .library(name: "SwiftPackageListObjc", type: .dynamic, targets: ["SwiftPackageListObjc"]),
+        .library(name: "SwiftPackageListUI", targets: ["SwiftPackageListUI"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "swift-package-list",
+            dependencies: [
+                .target(name: "SwiftPackageListCore"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+        .plugin(
+            name: "SwiftPackageListJSONPlugin",
+            capability: .buildTool(),
+            dependencies: [.target(name: "swift-package-list")]
+        ),
+        .plugin(
+            name: "SwiftPackageListPropertyListPlugin",
+            capability: .buildTool(),
+            dependencies: [.target(name: "swift-package-list")]
+        ),
+        .plugin(
+            name: "SwiftPackageListSettingsBundlePlugin",
+            capability: .buildTool(),
+            dependencies: [.target(name: "swift-package-list")]
+        ),
+        .plugin(
+            name: "SwiftPackageListPDFPlugin",
+            capability: .buildTool(),
+            dependencies: [.target(name: "swift-package-list")]
+        ),
+        .target(
+            name: "SwiftPackageListCore",
+            dependencies: ["SwiftPackageList"]
+        ),
+        .target(name: "SwiftPackageList"),
+        .target(name: "SwiftPackageListObjc"),
+        .target(
+            name: "SwiftPackageListUI",
+            dependencies: ["SwiftPackageList"],
+            resources: [.process("Resources")]
+        ),
+        .testTarget(name: "swift-package-list-tests"),
+        .testTarget(
+            name: "SwiftPackageListCoreTests",
+            dependencies: ["SwiftPackageListCore"],
+            resources: [.copy("Resources")]
+        ),
+        .testTarget(
+            name: "SwiftPackageListTests",
+            dependencies: ["SwiftPackageList"],
+            resources: [.process("Resources")]
+        ),
+        .testTarget(
+            name: "SwiftPackageListObjcTests",
+            dependencies: ["SwiftPackageListObjc"],
+            resources: [.process("Resources")]
+        ),
+    ]
+)


### PR DESCRIPTION
Resolves #70 

This PR adds a new feature which resolves the user facing package name from the Package.swift file instead of using the package identity from Package.resolved.
The feature can be activated via a new flag `resolves-packages-names` (opt-in)

Implementation unfortunately is "dumb" as in it iterates over the in memory package file String line by line and looks for the 'name' key. I don't have an idea right now on how to improve this though.

### Declaration
The program was tested solely for our own use cases, which might differ from yours.

### Link to provider information
https://github.com/mercedes-benz
