### PR TITLE
[Fix] Wrong Checkout Name

### DIFF
--- a/Sources/SwiftPackageListCore/Directories/Checkouts.swift
+++ b/Sources/SwiftPackageListCore/Directories/Checkouts.swift
@@ -13,7 +13,7 @@ struct Checkouts: Directory {
 
 extension Checkouts {
     func license(checkoutURL: URL) throws -> String? {
-        let checkoutName = checkoutURL.deletingPathExtension().lastPathComponent
+        let checkoutName = checkoutURL.packageIdentity
         let checkoutPath = url.appendingPathComponent(checkoutName)
         let packageFiles = try FileManager.default.contentsOfDirectory(
             at: checkoutPath,

--- a/Sources/SwiftPackageListCore/Files/PackageResolved.swift
+++ b/Sources/SwiftPackageListCore/Files/PackageResolved.swift
@@ -95,7 +95,7 @@ extension PackageResolved.Storage.V1.Object.Pin {
         } else {
             url = URL(fileURLWithPath: repositoryURL)
         }
-        return url.deletingPathExtension().lastPathComponent.lowercased()
+        return url.packageIdentity.lowercased()
     }
 }
 

--- a/Sources/SwiftPackageListCore/Utilites/URL+packageIdentity.swift
+++ b/Sources/SwiftPackageListCore/Utilites/URL+packageIdentity.swift
@@ -1,0 +1,18 @@
+//
+//  URL+packageIdentity.swift
+//  SwiftPackageListCore
+//
+//  Created by Felix Herrmann on 14.02.24.
+//
+
+import Foundation
+
+extension URL {
+    var packageIdentity: String {
+        // We cannot use .deletingPathExtension() here because repository names may contain dots.
+        if lastPathComponent.hasSuffix(".git") {
+            return String(lastPathComponent.dropLast(4))
+        }
+        return lastPathComponent
+    }
+}

--- a/Tests/SwiftPackageListCoreTests/URLExtensionTests.swift
+++ b/Tests/SwiftPackageListCoreTests/URLExtensionTests.swift
@@ -10,16 +10,22 @@ import XCTest
 
 final class URLExtensionTests: XCTestCase {
     func testPackageIdentity() throws {
-        let a = try XCTUnwrap(URL(string: "https://github.com/test/test"))
-        XCTAssertEqual(a.packageIdentity, "test")
+        let plain = try XCTUnwrap(URL(string: "https://github.com/test/test"))
+        XCTAssertEqual(plain.packageIdentity, "test")
         
-        let b = try XCTUnwrap(URL(string: "https://github.com/test/swift-test"))
-        XCTAssertEqual(b.packageIdentity, "swift-test")
+        let plainExtension = try XCTUnwrap(URL(string: "https://github.com/test/test.git"))
+        XCTAssertEqual(plainExtension.packageIdentity, "test")
         
-        let c = try XCTUnwrap(URL(string: "https://github.com/test/Test.swift"))
-        XCTAssertEqual(c.packageIdentity, "Test.swift")
+        let prefix = try XCTUnwrap(URL(string: "https://github.com/test/swift-test"))
+        XCTAssertEqual(prefix.packageIdentity, "swift-test")
         
-        let d = try XCTUnwrap(URL(string: "https://github.com/test/Test.swift.git"))
-        XCTAssertEqual(d.packageIdentity, "Test.swift")
+        let prefixExtension = try XCTUnwrap(URL(string: "https://github.com/test/swift-test.git"))
+        XCTAssertEqual(prefixExtension.packageIdentity, "swift-test")
+        
+        let `extension` = try XCTUnwrap(URL(string: "https://github.com/test/Test.swift"))
+        XCTAssertEqual(`extension`.packageIdentity, "Test.swift")
+        
+        let extensionExtension = try XCTUnwrap(URL(string: "https://github.com/test/Test.swift.git"))
+        XCTAssertEqual(extensionExtension.packageIdentity, "Test.swift")
     }
 }

--- a/Tests/SwiftPackageListCoreTests/URLExtensionTests.swift
+++ b/Tests/SwiftPackageListCoreTests/URLExtensionTests.swift
@@ -1,0 +1,25 @@
+//
+//  URLExtensionTests.swift
+//  SwiftPackageListCoreTests
+//
+//  Created by Felix Herrmann on 14.02.24.
+//
+
+import XCTest
+@testable import SwiftPackageListCore
+
+final class URLExtensionTests: XCTestCase {
+    func testPackageIdentity() throws {
+        let a = try XCTUnwrap(URL(string: "https://github.com/test/test"))
+        XCTAssertEqual(a.packageIdentity, "test")
+        
+        let b = try XCTUnwrap(URL(string: "https://github.com/test/swift-test"))
+        XCTAssertEqual(b.packageIdentity, "swift-test")
+        
+        let c = try XCTUnwrap(URL(string: "https://github.com/test/Test.swift"))
+        XCTAssertEqual(c.packageIdentity, "Test.swift")
+        
+        let d = try XCTUnwrap(URL(string: "https://github.com/test/Test.swift.git"))
+        XCTAssertEqual(d.packageIdentity, "Test.swift")
+    }
+}


### PR DESCRIPTION
This PR fixes the implementation of the package-identity construction used for the checkout-name and Package.resolved v1 identity.