### PR TITLE
[Feature] `--ignore-package` Option

### DIFF
--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -32,7 +32,7 @@ jobs:
           - generic/platform=tvOS
           - generic/platform=watchOS
           - generic/platform=visionOS
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
     - nesting
     - trailing_comma
+    - optional_data_string_conversion
 opt_in_rules:
     - anonymous_argument_in_multiline_closure
     - array_init

--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Configuration.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Configuration.swift
@@ -20,6 +20,7 @@ extension SwiftPackageListPlugin.Configuration {
     struct TargetConfiguration: Decodable {
         let outputType: OutputType?
         let requiresLicense: Bool? // swiftlint:disable:this discouraged_optional_boolean
+        let ignorePackages: [String]? // swiftlint:disable:this discouraged_optional_collection
     }
 }
 

--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
@@ -20,6 +20,10 @@ struct SwiftPackageListPlugin: Plugin {
         let outputPath = pluginWorkDirectory
         let requiresLicense = targetConfiguration?.requiresLicense ?? true
         
+        let ignorePackageArguments: [String] = targetConfiguration?.ignorePackages?.flatMap { identity in
+            return ["--ignore-package", identity]
+        } ?? []
+        
         let outputFiles: [Path]
         if let fileName = outputType.fileName {
             outputFiles = [outputPath.appending(fileName)]
@@ -37,7 +41,7 @@ struct SwiftPackageListPlugin: Plugin {
                     "--output-type", outputType.rawValue,
                     "--output-path", outputPath,
                     requiresLicense ? "--requires-license" : "",
-                ],
+                ] + ignorePackageArguments,
                 outputFiles: outputFiles
             )
         ]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In addition to that you can specify the following options:
 | --output-path \<output-path\>                                 | The path where the package-list file will be stored. (Not required for stdout output-type)                          |
 | --custom-file-name \<custom-file-name\>                       | A custom filename to be used instead of the default ones.                                                           |
 | --requires-license                                            | Will skip the packages without a license-file.                                                                      |
-| --ignore-package \<package-identity\>                         | Will skip a package with the specified identity. (may be repeated multiple times)                                   |
+| --ignore-package \<package-identity\>                         | Will skip a package with the specified identity. (This option may be repeated multiple times)                       |
 | --version                                                     | Show the version.                                                                                                   |
 | -h, --help                                                    | Show help information.                                                                                              |
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In addition to that you can specify the following options:
 | --output-path \<output-path\>                                 | The path where the package-list file will be stored. (Not required for stdout output-type)                          |
 | --custom-file-name \<custom-file-name\>                       | A custom filename to be used instead of the default ones.                                                           |
 | --requires-license                                            | Will skip the packages without a license-file.                                                                      |
+| --ignore-base-url                                             | Will skip packages from repositories that match the provided base URL (may be repeated multiple times).             |
 | --version                                                     | Show the version.                                                                                                   |
 | -h, --help                                                    | Show help information.                                                                                              |
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In addition to that you can specify the following options:
 | --output-path \<output-path\>                                 | The path where the package-list file will be stored. (Not required for stdout output-type)                          |
 | --custom-file-name \<custom-file-name\>                       | A custom filename to be used instead of the default ones.                                                           |
 | --requires-license                                            | Will skip the packages without a license-file.                                                                      |
-| --ignore-base-url                                             | Will skip packages from repositories that match the provided base URL (may be repeated multiple times).             |
+| --ignore-package \<package-identity\>                         | Will skip a package with the specified identity. (may be repeated multiple times)                                   |
 | --version                                                     | Show the version.                                                                                                   |
 | -h, --help                                                    | Show help information.                                                                                              |
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ By default this will use the JSON output with `--requires-license` but you can c
         },
         "Target 2" : {
             "outputType" : "json",
-            "requiresLicense" : true
+            "requiresLicense" : true,
+            "ignorePackages" : [
+                "swift-package-list",
+                "swift-argument-parser",
+            ]
         }
     }
 }

--- a/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ArgumentParser
+import SwiftPackageList
 import SwiftPackageListCore
 
 extension SwiftPackageList {
@@ -32,5 +33,12 @@ extension SwiftPackageList.OutputOptions {
     var outputGeneratorOptions: OutputGeneratorOptions {
         let outputURL = outputPath.map { URL(fileURLWithPath: $0) }
         return OutputGeneratorOptions(outputURL: outputURL, customFileName: customFileName)
+    }
+}
+
+extension SwiftPackageList.OutputOptions {
+    func filter(package: Package) -> Bool {
+        if requiresLicense && !package.hasLicense { return false }
+        return !ignorePackage.contains(package.identity)
     }
 }

--- a/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
@@ -22,6 +22,9 @@ extension SwiftPackageList {
         
         @Flag(help: "Will skip the packages without a license-file.")
         var requiresLicense = false
+        
+        @Option(parsing: .singleValue, help: "Skip packages from repositories that match the provided base URL. (This option may be repeated multiple times)")
+        var ignoreBaseURL: [String]
     }
 }
 

--- a/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
@@ -26,7 +26,10 @@ extension SwiftPackageList {
         
         @Option(
             name: .customLong("ignore-package"),
-            help: "Will skip a package with the specified identity. (This option may be repeated multiple times)")
+            help: ArgumentHelp(
+                "Will skip a package with the specified identity. (This option may be repeated multiple times)",
+                valueName: "package-identity"
+            )
         )
         var ignoredPackageIdentities: [String] = []
     }

--- a/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
@@ -23,8 +23,8 @@ extension SwiftPackageList {
         @Flag(help: "Will skip the packages without a license-file.")
         var requiresLicense = false
         
-        @Option(parsing: .singleValue, help: "Skip packages from repositories that match the provided base URL. (This option may be repeated multiple times)")
-        var ignoreBaseURL: [String]
+        @Option(parsing: .singleValue, help: "Will skip a package with the specified identity. (This option may be repeated multiple times)")
+        var ignorePackage: [String] = []
     }
 }
 

--- a/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+OutputOptions.swift
@@ -24,8 +24,11 @@ extension SwiftPackageList {
         @Flag(help: "Will skip the packages without a license-file.")
         var requiresLicense = false
         
-        @Option(parsing: .singleValue, help: "Will skip a package with the specified identity. (This option may be repeated multiple times)")
-        var ignorePackage: [String] = []
+        @Option(
+            name: .customLong("ignore-package"),
+            help: "Will skip a package with the specified identity. (This option may be repeated multiple times)")
+        )
+        var ignoredPackageIdentities: [String] = []
     }
 }
 
@@ -39,6 +42,6 @@ extension SwiftPackageList.OutputOptions {
 extension SwiftPackageList.OutputOptions {
     func filter(package: Package) -> Bool {
         if requiresLicense && !package.hasLicense { return false }
-        return !ignorePackage.contains(package.identity)
+        return !ignoredPackageIdentities.contains(package.identity)
     }
 }

--- a/Sources/swift-package-list/SwiftPackageList.swift
+++ b/Sources/swift-package-list/SwiftPackageList.swift
@@ -40,11 +40,11 @@ struct SwiftPackageList: ParsableCommand {
 }
 
 extension SwiftPackageList.OutputOptions {
-    func filter(_ isIncluded: Package) -> Bool {
-        if requiresLicense, !isIncluded.hasLicense {
+    func filter(_ package: Package) -> Bool {
+        if requiresLicense, !package.hasLicense {
             return false
         }
-        for baseURL in ignoreBaseURL where isIncluded.repositoryURL.absoluteString.hasPrefix(baseURL) {
+        for ignored in ignorePackage where package.identity == ignored {
             return false
         }
         return true

--- a/Sources/swift-package-list/SwiftPackageList.swift
+++ b/Sources/swift-package-list/SwiftPackageList.swift
@@ -26,8 +26,7 @@ struct SwiftPackageList: ParsableCommand {
         let projectFileURL = URL(fileURLWithPath: inputOptions.projectPath)
         let projectType = try ProjectType(fileURL: projectFileURL)
         let project = try projectType.project(fileURL: projectFileURL, options: inputOptions.projectOptions)
-        
-        let packages = try project.packages().filter(outputOptions.filter)
+        let packages = try project.packages().filter(outputOptions.filter(package:))
         
         let outputType = outputOptions.outputType
         let outputGenerator = try outputType.outputGenerator(
@@ -36,17 +35,5 @@ struct SwiftPackageList: ParsableCommand {
             options: outputOptions.outputGeneratorOptions
         )
         try outputGenerator.generateOutput()
-    }
-}
-
-extension SwiftPackageList.OutputOptions {
-    func filter(_ package: Package) -> Bool {
-        if requiresLicense, !package.hasLicense {
-            return false
-        }
-        for ignored in ignorePackage where package.identity == ignored {
-            return false
-        }
-        return true
     }
 }


### PR DESCRIPTION
This PR adds a `--ignore-package` option to the CLI for filtering out specific packages by their identity; to expose this functionality to the SPM plugin there is a new optional `"ignorePackages"` field in the config.

---
_Original message:_

Hi, I'm not sure what you look for in a contribution, so opening this as a starting point for discussion.

We're using swift-package-list in our project (really love it, thanks for making this project) and would like a way to filter out our own packages from the generated Acknowledgements. This PR adds the ability to run a command like so 

```shell
swift-package-list ElementX.xcodeproj --requires-license --ignore-base-url https://github.com/element-hq --output-type settings-bundle --output-path ElementX/SupportingFiles
```

This would ignore any packages who's repository URLs are `https://github.com/element-hq/…`

Let me know if you would prefer to do this another way, tweak the naming, or if there is more implementation required for this PR to be mergeable.