### PR TITLE
[Infrastructure] Remove xcresulttool

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release-build:
     name: Release Build
-    runs-on: macos-14
+    runs-on: macos-15
     outputs:
       sha: ${{ steps.sha256.outputs.sha256 }}
     env:

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -60,9 +60,4 @@ jobs:
           xcodebuild \
           -scheme SwiftPackageList-Package \
           -destination 'platform=macOS' \
-          -resultBundlePath TestResults \
           test
-      - uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: TestResults.xcresult
-        if: success() || failure()

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -47,7 +47,7 @@ jobs:
   test:
     name: Test
     needs: build-libraries
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/Tests/SwiftPackageListCoreTests/PDFGeneratorTests.swift
+++ b/Tests/SwiftPackageListCoreTests/PDFGeneratorTests.swift
@@ -58,14 +58,25 @@ final class PDFGeneratorTests: XCTestCase {
         XCTAssertEqual(attributes["Title"] as? String, "Project_Acks_File_\(creationDate)")
         XCTAssertEqual(attributes["Creator"] as? String, "swift-package-list")
         
-        let expectedOutput = """
-        Acknowledgements
-        Portions of this SwiftPackageList Software may utilize the following \
-        copyrighted material, the use of which is hereby acknowledged.
-        test
-        MIT
-        
-        """
+        let expectedOutput: String
+        if #available(macOS 15.0, *) {
+            expectedOutput = """
+            Acknowledgements
+            Portions of this SwiftPackageList Software may utilize the following \
+            copyrighted material, the use of which is hereby acknowledged.
+            test
+            MIT
+            """
+        } else {
+            expectedOutput = """
+            Acknowledgements
+            Portions of this SwiftPackageList Software may utilize the following \
+            copyrighted material, the use of which is hereby acknowledged.
+            test
+            MIT
+            
+            """
+        }
         XCTAssertEqual(output.string, expectedOutput)
     }
 }

--- a/Tests/SwiftPackageListCoreTests/PDFGeneratorTests.swift
+++ b/Tests/SwiftPackageListCoreTests/PDFGeneratorTests.swift
@@ -62,8 +62,8 @@ final class PDFGeneratorTests: XCTestCase {
         if #available(macOS 15.0, *) {
             expectedOutput = """
             Acknowledgements
-            Portions of this SwiftPackageList Software may utilize the following \
-            copyrighted material, the use of which is hereby acknowledged.
+            Portions of this SwiftPackageList Software may utilize the following copyrighted
+            material, the use of which is hereby acknowledged.
             test
             MIT
             """


### PR DESCRIPTION
This PR removes the xcresulttool action due to its unmaintained state; once Xcode 16 support is added and node 16 is dropped we can consider re-adding it.

In addition to that this PR migrates all macOS jobs to Sonoma.