### PR TITLE
[Fix] Wrong Arabic Translation

### DIFF
--- a/Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator+Language.swift
+++ b/Sources/SwiftPackageListCore/Output Generation/SettingsBundle/SettingsBundleGenerator+Language.swift
@@ -38,7 +38,7 @@ extension SettingsBundleGenerator.Language {
         switch self {
         case .ar:
             return [
-                .acknowledgements: "مخزن",
+                .acknowledgements: "إقرارات",
             ]
         case .de:
             return [

--- a/Sources/SwiftPackageListUI/Resources/ar.lproj/Localizable.strings
+++ b/Sources/SwiftPackageListUI/Resources/ar.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 
 // Navigation bar title of the license list
-"acknowledgments.title" = "مخزن";
+"acknowledgments.title" = "إقرارات";
 
 // Section title for the license list
 "acknowledgments.section-title" = "التراخيص";


### PR DESCRIPTION
Thanks for this nice tool! I found the Arabic localization was mistranslated

The current one "مخزن" means storage or warehouse.

The proposed change "الشكر والتقدير" means acknowledgments or being thankful and appreciation.

> [!NOTE]  
> Acknowledgment in English has multiple meanings, in this context it could be one of two, either "Recognition" or "Appreciation" and I believe it's the latter.