### PR TITLE
[Fix] Wrong assumption of `Package.revision` being non-optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ The Settings Bundle and the UI-components are currently localized in the followi
 
 > If a language has mistakes or is missing, feel free to create an issue or open a pull request.
 
+## Known limitations
+
+- SwiftPackageList won't include license files from packages that are located in a registry like Artifactory.
+
 
 ## License
 

--- a/Sources/SwiftPackageList/Package.swift
+++ b/Sources/SwiftPackageList/Package.swift
@@ -28,9 +28,9 @@ public struct Package: Sendable, Hashable, Codable {
     
     /// The exact revision/commit.
     ///
-    /// This is always present, regardless if the package's dependency-rule is version or branch.
-    public let revision: String
-    
+    /// Could be `nil` if the package is located in a registry.
+    public let revision: String?
+
     /// The URL to the git-repository.
     public let repositoryURL: URL
     
@@ -44,7 +44,7 @@ public struct Package: Sendable, Hashable, Codable {
         name: String,
         version: String?,
         branch: String?,
-        revision: String,
+        revision: String?,
         repositoryURL: URL,
         license: String?
     ) {

--- a/Sources/SwiftPackageListCore/Files/PackageResolved.swift
+++ b/Sources/SwiftPackageListCore/Files/PackageResolved.swift
@@ -105,7 +105,7 @@ extension PackageResolved.Storage {
     struct V2: Decodable {
         struct Pin: Decodable {
             struct State: Decodable {
-                let revision: String
+                let revision: String?
                 let version: String?
                 let branch: String?
             }

--- a/Tests/SwiftPackageListCoreTests/PackageResolvedTests.swift
+++ b/Tests/SwiftPackageListCoreTests/PackageResolvedTests.swift
@@ -67,7 +67,29 @@ final class PackageResolvedTests: XCTestCase {
             XCTAssertEqual((error as? RuntimeError)?.description, "Version 999 of Package.resolved is not supported")
         }
     }
-    
+
+    func testPackagesFromRegistry() throws {
+        let url = Bundle.module.url(
+            forResource: "Package_registry",
+            withExtension: "resolved",
+            subdirectory: "Resources/PackageResolved"
+        )
+        let unwrappedURL = try XCTUnwrap(url)
+        let packageResolved = try PackageResolved(url: unwrappedURL)
+
+        guard case .v2(let packageResolved) = packageResolved.storage else {
+            XCTFail("\(unwrappedURL.path) was not recognized as v2")
+            return
+        }
+        XCTAssertEqual(packageResolved.version, 2)
+        XCTAssertEqual(packageResolved.pins[0].identity, "package.in.registry.like.artifactory")
+        XCTAssertEqual(packageResolved.pins[0].kind, "registry")
+        XCTAssertEqual(packageResolved.pins[0].location, "")
+        XCTAssertNil(packageResolved.pins[0].state.branch)
+        XCTAssertNil(packageResolved.pins[0].state.revision)
+        XCTAssertEqual(packageResolved.pins[0].state.version, "1.2.3")
+    }
+
     func testVersion1IdentityConstruction() {
         let remotePin = PackageResolved.Storage.V1.Object.Pin(
             package: "",

--- a/Tests/SwiftPackageListCoreTests/Resources/PackageResolved/Package_registry.resolved
+++ b/Tests/SwiftPackageListCoreTests/Resources/PackageResolved/Package_registry.resolved
@@ -1,0 +1,13 @@
+{
+    "pins": [
+        {
+            "identity" : "package.in.registry.like.artifactory",
+            "kind" : "registry",
+            "location" : "",
+            "state" : {
+                "version" : "1.2.3"
+            }
+        }
+    ],
+    "version": 2
+}


### PR DESCRIPTION
My team recently had to move a company internal package to Artifactory and this broke SwiftPackageList parsing the `Package.resolved` file on consumer side. There was a wrong assumption of the field `revision` always being set. However this field is optional (see SPM code: https://github.com/swiftlang/swift-package-manager/blob/release/6.0.2/Sources/PackageGraph/PinsStore.swift#L443) and will be empty for `registry` packages.

I fixed this assumption and made that property optional. I also added a test case with a sample entry on how a registry package looks in the`Package.resolved` file.

Furthermore, just to be explicit about what is supported and what isn't, I added a section in the Readme file to note that SwiftPackageList is not able to get license files out of packages received from registries. Registry packages are usually closed source, so it won't matter (usually), but stating it explicitly might save someone quite a lot of headache.