### PR TITLE
Add option to provide additional custom packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In addition to that you can specify the following options:
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | --custom-derived-data-path \<custom-derived-data-path\>       | A custom path to your DerivedData-folder.                                                                           |
 | --custom-source-packages-path \<custom-source-packages-path\> | A custom path to the SourcePackages-folder.                                                                         |
-| --custom-license-file \<custom-license-file\>                 | A custom path for a file containing custom packages in a JSON format.                                               |
+| --custom-packages-file \<custom-packages-file\>               | A custom path for a file containing custom packages in a JSON format.                                               |
 | --output-type \<output-type\>                                 | The type of output for the package-list. (values: stdout, json, plist, settings-bundle, pdf; default: stdout)       |
 | --output-path \<output-path\>                                 | The path where the package-list file will be stored. (Not required for stdout output-type)                          |
 | --custom-file-name \<custom-file-name\>                       | A custom filename to be used instead of the default ones.                                                           |
@@ -246,16 +246,16 @@ var body: some View {
 
 ## Custom Packages
 
-To include the custom packages/licenses in the generated package list file/view, you can use the `--custom-license-file` option and provide the file path to a JSON file using the following structure:
+To include the custom packages/licenses in the generated package list file/view, you can use the `--custom-packages-file` option and provide the file path to a JSON file using the following structure:
 
 ```
 [
   {
     "identity" : "custom-license",
-    "license" : "testlicensetext",
+    "license" : "Custom License Description",
     "name" : "custom-license",
-    "repositoryURL" : "https:\/\/github.com\/org\/repo",
-    "revision" : "abcdefghijl123456",
+    "repositoryURL" : "https://github.com/org/repo",
+    "revision" : "commit-hash",
     "version" : "1.0.0"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -251,9 +251,9 @@ To include the custom packages/licenses in the generated package list file/view,
 ```
 [
   {
-    "identity" : "custom-license",
-    "license" : "Custom License Description",
-    "name" : "custom-license",
+    "identity" : "custom-packages",
+    "license" : "Custom Package Description",
+    "name" : "custom-package",
     "repositoryURL" : "https://github.com/org/repo",
     "revision" : "commit-hash",
     "version" : "1.0.0"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In addition to that you can specify the following options:
 | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | --custom-derived-data-path \<custom-derived-data-path\>       | A custom path to your DerivedData-folder.                                                                           |
 | --custom-source-packages-path \<custom-source-packages-path\> | A custom path to the SourcePackages-folder.                                                                         |
+| --custom-license-file \<custom-license-file\>                 | A custom path for a file containing custom packages in a JSON format.                                               |
 | --output-type \<output-type\>                                 | The type of output for the package-list. (values: stdout, json, plist, settings-bundle, pdf; default: stdout)       |
 | --output-path \<output-path\>                                 | The path where the package-list file will be stored. (Not required for stdout output-type)                          |
 | --custom-file-name \<custom-file-name\>                       | A custom filename to be used instead of the default ones.                                                           |
@@ -243,6 +244,22 @@ var body: some View {
 }
 ```
 
+## Custom Packages
+
+To include the custom packages/licenses in the generated package list file/view, you can use the `--custom-license-file` option and provide the file path to a JSON file using the following structure:
+
+```
+[
+  {
+    "identity" : "custom-license",
+    "license" : "testlicensetext",
+    "name" : "custom-license",
+    "repositoryURL" : "https:\/\/github.com\/org\/repo",
+    "revision" : "abcdefghijl123456",
+    "version" : "1.0.0"
+  }
+]
+```
 
 ## Localization
 

--- a/Sources/SwiftPackageListCore/Project/Project.swift
+++ b/Sources/SwiftPackageListCore/Project/Project.swift
@@ -22,3 +22,14 @@ extension Project {
         return nil
     }
 }
+
+// MARK: Custom Packages
+extension Project {
+    public func customPackages(_ filePath: String?) throws -> [Package] {
+        guard let filePath else {
+            return []
+        }
+        let data = try Data(contentsOf: URL(fileURLWithPath: filePath))
+        return try JSONDecoder().decode([Package].self, from: data)
+    }
+}

--- a/Sources/swift-package-list/SwiftPackageList+InputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+InputOptions.swift
@@ -22,6 +22,9 @@ extension SwiftPackageList {
         
         @Option(help: "A custom path to the SourcePackages-folder.", completion: .directory)
         var customSourcePackagesPath: String?
+        
+        @Option(help: "A file containing custom licenses.", completion: .file(extensions: ["json"]))
+        var customLicenseFile: String?
     }
 }
 

--- a/Sources/swift-package-list/SwiftPackageList+InputOptions.swift
+++ b/Sources/swift-package-list/SwiftPackageList+InputOptions.swift
@@ -23,8 +23,8 @@ extension SwiftPackageList {
         @Option(help: "A custom path to the SourcePackages-folder.", completion: .directory)
         var customSourcePackagesPath: String?
         
-        @Option(help: "A file containing custom licenses.", completion: .file(extensions: ["json"]))
-        var customLicenseFile: String?
+        @Option(help: "A file containing custom packages.", completion: .file(extensions: ["json"]))
+        var customPackagesFile: String?
     }
 }
 

--- a/Sources/swift-package-list/SwiftPackageList.swift
+++ b/Sources/swift-package-list/SwiftPackageList.swift
@@ -27,7 +27,7 @@ struct SwiftPackageList: ParsableCommand {
         let projectType = try ProjectType(fileURL: projectFileURL)
         let project = try projectType.project(fileURL: projectFileURL, options: inputOptions.projectOptions)
         let packages = try project.packages().filter(outputOptions.filter(package:))
-        let customPackages = try project.customPackages(inputOptions.customLicenseFile)
+        let customPackages = try project.customPackages(inputOptions.customPackagesFile)
         
         let outputType = outputOptions.outputType
         let outputGenerator = try outputType.outputGenerator(

--- a/Sources/swift-package-list/SwiftPackageList.swift
+++ b/Sources/swift-package-list/SwiftPackageList.swift
@@ -27,10 +27,11 @@ struct SwiftPackageList: ParsableCommand {
         let projectType = try ProjectType(fileURL: projectFileURL)
         let project = try projectType.project(fileURL: projectFileURL, options: inputOptions.projectOptions)
         let packages = try project.packages().filter(outputOptions.filter(package:))
+        let customPackages = try project.customPackages(inputOptions.customLicenseFile)
         
         let outputType = outputOptions.outputType
         let outputGenerator = try outputType.outputGenerator(
-            packages: packages,
+            packages: packages + customPackages,
             project: project,
             options: outputOptions.outputGeneratorOptions
         )

--- a/Tests/SwiftPackageListCoreTests/ProjectTests.swift
+++ b/Tests/SwiftPackageListCoreTests/ProjectTests.swift
@@ -158,4 +158,20 @@ final class ProjectTests: XCTestCase {
         XCTAssertEqual(tuistDependencies.name, "TuistDependencies")
         XCTAssertEqual(tuistDependencies.organizationName, "Test Inc.")
     }
+    
+    func testCustomPackages() throws {
+        let url = Bundle.module.url(forResource: "Project", withExtension: "xcodeproj", subdirectory: "Resources/XcodeProject")
+        let unwrappedURL = try XCTUnwrap(url)
+        
+        let projectType = try XCTUnwrap(ProjectType(fileURL: unwrappedURL))
+        XCTAssertEqual(projectType, .xcodeProject)
+        
+        let project = try projectType.project(fileURL: unwrappedURL)
+        let xcodeProject = try XCTUnwrap(project as? XcodeProject)
+        
+        let customPackagesURL = Bundle.module.url(forResource: "custom-packages", withExtension: "json", subdirectory: "Resources/Project")
+        let unwrappedcustomPackagesURL = try XCTUnwrap(customPackagesURL)
+        let customPackages = try xcodeProject.customPackages(unwrappedcustomPackagesURL.absoluteString.replacingOccurrences(of: "file://", with: ""))
+        XCTAssertNotNil(customPackages)
+    }
 }

--- a/Tests/SwiftPackageListCoreTests/Resources/Project/custom-packages.json
+++ b/Tests/SwiftPackageListCoreTests/Resources/Project/custom-packages.json
@@ -1,0 +1,10 @@
+[
+  {
+    "identity" : "custom-packages",
+    "license" : "Custom Package Description",
+    "name" : "custom-package",
+    "repositoryURL" : "https://github.com/org/repo",
+    "revision" : "commit-hash",
+    "version" : "1.0.0"
+  }
+]


### PR DESCRIPTION
### Overview
This PR proposes an additional capability to append custom packages/licenses added manually or through other sources to the package list provided by this package in addition to the packages automatically fetched using Swift Package Manager.   

### Implementation Details
- The proposed feature leverages the existing structure of the JSON output type. 
- Users can specify a custom path to a file containing custom packages/licenses. This file will be appended to the automatically fetched packages.
- A test for checking the parsing of the custom packages file has been added.

### Benefits
- Enhances flexibility: Users can include packages and licenses that are not fetched via SPM. 
- Maintains consistency: Integrates seamlessly with the existing JSON output format.

I would highly appreciate your feedback on this approach. If this feature does not align with your expectations, I'd be happy to implement adjustments.