### PR TITLE
[Feature] WorkspaceState V7

### DIFF
--- a/Sources/SwiftPackageListCore/Files/WorkspaceState.swift
+++ b/Sources/SwiftPackageListCore/Files/WorkspaceState.swift
@@ -174,37 +174,60 @@ extension WorkspaceState {
     func packageName(for identity: String) -> String? {
         switch self.storage {
         case .v4(let v4):
-            for artifact in v4.object.artifacts where artifact.packageRef.identity == identity {
-                return artifact.packageRef.name
-            }
-            
-            for dependency in v4.object.dependencies where dependency.packageRef.identity == identity {
-                return dependency.packageRef.name
-            }
+            return v4.packageName(for: identity)
         case .v5(let v5):
-            for artifact in v5.object.artifacts where artifact.packageRef.identity == identity {
-                return artifact.packageRef.name
-            }
-            
-            for dependency in v5.object.dependencies where dependency.packageRef.identity == identity {
-                return dependency.packageRef.name
-            }
+            return v5.packageName(for: identity)
         case .v6(let v6):
-            for artifact in v6.object.artifacts where artifact.packageRef.identity == identity {
-                return artifact.packageRef.name
-            }
-            
-            for dependency in v6.object.dependencies where dependency.packageRef.identity == identity {
-                return dependency.packageRef.name
-            }
+            return v6.packageName(for: identity)
         case .v7(let v7):
-            for artifact in v7.object.artifacts where artifact.packageRef.identity == identity {
-                return artifact.packageRef.name
-            }
-            
-            for dependency in v7.object.dependencies where dependency.packageRef.identity == identity {
-                return dependency.packageRef.name
-            }
+            return v7.packageName(for: identity)
+        }
+    }
+}
+
+extension WorkspaceState.Storage.V4 {
+    func packageName(for identity: String) -> String? {
+        for artifact in object.artifacts where artifact.packageRef.identity == identity {
+            return artifact.packageRef.name
+        }
+        for dependency in object.dependencies where dependency.packageRef.identity == identity {
+            return dependency.packageRef.name
+        }
+        return nil
+    }
+}
+
+extension WorkspaceState.Storage.V5 {
+    func packageName(for identity: String) -> String? {
+        for artifact in object.artifacts where artifact.packageRef.identity == identity {
+            return artifact.packageRef.name
+        }
+        for dependency in object.dependencies where dependency.packageRef.identity == identity {
+            return dependency.packageRef.name
+        }
+        return nil
+    }
+}
+
+extension WorkspaceState.Storage.V6 {
+    func packageName(for identity: String) -> String? {
+        for artifact in object.artifacts where artifact.packageRef.identity == identity {
+            return artifact.packageRef.name
+        }
+        for dependency in object.dependencies where dependency.packageRef.identity == identity {
+            return dependency.packageRef.name
+        }
+        return nil
+    }
+}
+
+extension WorkspaceState.Storage.V7 {
+    func packageName(for identity: String) -> String? {
+        for artifact in object.artifacts where artifact.packageRef.identity == identity {
+            return artifact.packageRef.name
+        }
+        for dependency in object.dependencies where dependency.packageRef.identity == identity {
+            return dependency.packageRef.name
         }
         return nil
     }

--- a/Tests/SwiftPackageListCoreTests/Resources/WorkspaceState/workspace-state_v7.json
+++ b/Tests/SwiftPackageListCoreTests/Resources/WorkspaceState/workspace-state_v7.json
@@ -1,0 +1,53 @@
+{
+  "object" : {
+    "artifacts" : [
+
+    ],
+    "dependencies" : [
+      {
+        "basedOn" : null,
+        "packageRef" : {
+          "identity" : "swift-syntax",
+          "kind" : "remoteSourceControl",
+          "location" : "https://github.com/swiftlang/swift-syntax.git",
+          "name" : "swift-syntax"
+        },
+        "state" : {
+          "checkoutState" : {
+            "revision" : "0687f71944021d616d34d922343dcef086855920",
+            "version" : "600.0.1"
+          },
+          "name" : "sourceControlCheckout"
+        },
+        "subpath" : "swift-syntax"
+      }
+    ],
+    "prebuilts" : [
+      {
+        "cModules" : [
+          "_SwiftSyntaxCShims"
+        ],
+        "identity" : "swift-syntax",
+        "libraryName" : "MacroSupport",
+        "path" : "/Users/test/test-workspace-state-v7/.build/prebuilts/swift-syntax/600.0.1/6.1-MacroSupport-macos_aarch64",
+        "products" : [
+          "SwiftBasicFormat",
+          "SwiftCompilerPlugin",
+          "SwiftDiagnostics",
+          "SwiftIDEUtils",
+          "SwiftOperators",
+          "SwiftParser",
+          "SwiftParserDiagnostics",
+          "SwiftRefactor",
+          "SwiftSyntax",
+          "SwiftSyntaxMacros",
+          "SwiftSyntaxMacroExpansion",
+          "SwiftSyntaxMacrosTestSupport",
+          "SwiftSyntaxMacrosGenericTestSupport"
+        ],
+        "version" : "600.0.1"
+      }
+    ]
+  },
+  "version" : 7
+}

--- a/Tests/SwiftPackageListCoreTests/WorkspaceStateTests.swift
+++ b/Tests/SwiftPackageListCoreTests/WorkspaceStateTests.swift
@@ -30,6 +30,25 @@ final class WorkspaceStateTests: XCTestCase {
         }
     }
     
+    func testVersion7() throws {
+        let url = Bundle.module.url(
+            forResource: "workspace-state_v7",
+            withExtension: "json",
+            subdirectory: "Resources/WorkspaceState"
+        )
+        let unwrappedURL = try XCTUnwrap(url)
+        let workspaceState = try WorkspaceState(url: unwrappedURL)
+        
+        guard case .v7(let workspaceState_V7) = workspaceState.storage else {
+            XCTFail("\(unwrappedURL.path) was not recognized as v7")
+            return
+        }
+        XCTAssertEqual(workspaceState_V7.version, 7)
+        XCTAssertTrue(workspaceState_V7.object.artifacts.isEmpty)
+        XCTAssertEqual(workspaceState_V7.object.dependencies[0].packageRef.identity, "swift-syntax")
+        XCTAssertEqual(workspaceState_V7.object.dependencies[0].packageRef.name, "swift-syntax")
+    }
+    
     func testUnsupportedVersion() throws {
         let url = Bundle.module.url(
             forResource: "workspace-state_v999",

--- a/Tests/SwiftPackageListCoreTests/WorkspaceStateTests.swift
+++ b/Tests/SwiftPackageListCoreTests/WorkspaceStateTests.swift
@@ -18,16 +18,15 @@ final class WorkspaceStateTests: XCTestCase {
         let unwrappedURL = try XCTUnwrap(url)
         let workspaceState = try WorkspaceState(url: unwrappedURL)
         
-        switch workspaceState.storage {
-        case .v6(let workspaceState_V6):
-            XCTAssertEqual(workspaceState_V6.version, 6)
-            XCTAssertEqual(workspaceState_V6.object.artifacts[0].packageRef.identity, "intercom-ios-sp")
-            XCTAssertEqual(workspaceState_V6.object.artifacts[0].packageRef.name, "Intercom")
-            XCTAssertEqual(workspaceState_V6.object.dependencies[0].packageRef.identity, "collectionconcurrencykit")
-            XCTAssertEqual(workspaceState_V6.object.dependencies[0].packageRef.name, "CollectionConcurrencyKit")
-        default:
+        guard case .v6(let workspaceState_V6) = workspaceState.storage else {
             XCTFail("\(unwrappedURL.path) was not recognized as v6")
+            return
         }
+        XCTAssertEqual(workspaceState_V6.version, 6)
+        XCTAssertEqual(workspaceState_V6.object.artifacts[0].packageRef.identity, "intercom-ios-sp")
+        XCTAssertEqual(workspaceState_V6.object.artifacts[0].packageRef.name, "Intercom")
+        XCTAssertEqual(workspaceState_V6.object.dependencies[0].packageRef.identity, "collectionconcurrencykit")
+        XCTAssertEqual(workspaceState_V6.object.dependencies[0].packageRef.name, "CollectionConcurrencyKit")
     }
     
     func testVersion7() throws {


### PR DESCRIPTION
This PR adds support for version 7 of the `workspace-state.json`.

I was able to produce one containing prebuilt data with `swift build --enable-experimental-prebuilts` on a macro package and it looks like we don't have to handle anything additional.