### PR TITLE
[Fix] `pluginWorkDirectory` moved in Xcode 16.3

### DIFF
--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Error.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Error.swift
@@ -23,7 +23,7 @@ extension SwiftPackageListPlugin.Error: CustomDebugStringConvertible {
         case .configurationInvalid(path: let path, underlyingError: let error):
             return "The configuration at \(path.string) has an invalid format: \(error)"
         case .sourcePackagesNotFound(pluginWorkDirectory: let directory):
-            return "SourcePackages directory not found in \(directory.string)"
+            return "SourcePackages directory not found from \(directory.string)"
         }
     }
 }

--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
@@ -53,12 +53,18 @@ struct SwiftPackageListPlugin: Plugin {
     
     private func sourcePackagesDirectory(pluginWorkDirectory: Path) throws -> Path {
         var path = pluginWorkDirectory
-        while path.lastComponent != "SourcePackages" {
+        var projectDirectory: String?
+        while path.lastComponent != "DerivedData" {
             guard path.string != "/" else {
                 throw SwiftPackageListPlugin.Error.sourcePackagesNotFound(pluginWorkDirectory: pluginWorkDirectory)
             }
+            projectDirectory = path.lastComponent
             path = path.removingLastComponent()
         }
-        return path
+        
+        guard let projectDirectory else {
+            throw SwiftPackageListPlugin.Error.sourcePackagesNotFound(pluginWorkDirectory: pluginWorkDirectory)
+        }
+        return path.appending([projectDirectory, "SourcePackages"])
     }
 }


### PR DESCRIPTION
This PR changes the SourcePackages path creation in the plugin which now supports `pluginWorkDirectory` in any subdirectory in DerivedData instead of only SourcePackages. This change is required for the new directory structure in Xcode 16.3.