### PR TITLE
Fix wrong path calculation as reported in #141

### DIFF
--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
@@ -5,6 +5,7 @@
 //  Created by Felix Herrmann on 03.02.24.
 //
 
+import Foundation
 import PackagePlugin
 
 @main
@@ -65,6 +66,16 @@ struct SwiftPackageListPlugin: Plugin {
         guard let projectDirectory else {
             throw SwiftPackageListPlugin.Error.sourcePackagesNotFound(pluginWorkDirectory: pluginWorkDirectory)
         }
-        return path.appending([projectDirectory, "SourcePackages"])
+        let possibleSourcePackagesPaths = [
+            path.appending([projectDirectory, "SourcePackages"]),
+            path.appending("SourcePackages")
+        ]
+        let sourcePackagesPath = possibleSourcePackagesPaths.first {
+            FileManager.default.fileExists(atPath: $0.string)
+        }
+        guard let sourcePackagesPath else {
+            throw SwiftPackageListPlugin.Error.sourcePackagesNotFound(pluginWorkDirectory: pluginWorkDirectory)
+        }
+        return sourcePackagesPath
     }
 }


### PR DESCRIPTION
This PR fixes a wrong `--custom-packages-file-path` in Xcode cloud and some local xcodebuild builds. See #141 for more details.