### PR TITLE
Add `customSourcePackagesPath` to build plugin

### DIFF
--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Configuration.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.Configuration.swift
@@ -22,6 +22,7 @@ extension SwiftPackageListPlugin.Configuration {
         let requiresLicense: Bool? // swiftlint:disable:this discouraged_optional_boolean
         let ignorePackages: [String]? // swiftlint:disable:this discouraged_optional_collection
         let customPackagesFilePaths: [String]? // swiftlint:disable:this discouraged_optional_collection
+        let customSourcePackagesPath: Path?
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ By default this will use the JSON output with `--requires-license` but you can c
             ],
             "customPackagesFilePaths" : [
                 "custom-packages.json",
-            ]
+            ],
+            "customSourcePackagesPath" : "./SourcePackages"
         }
     }
 }


### PR DESCRIPTION
When using `xcodebuild` from the CLI with a `-clonedSourcePackagesDirPath` flag, this plugin fails. By adding a custom path to the config file we can leverage this value, and set the path up in a custom way to match our CLI. Because of the way the plugin was already doing the `possibleSourcePackagesPaths` check we can just add this path there and it doesn't break local builds.