### PR TITLE
Update Tuist instructions in the readme + mise install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Currently supported are:
 - `*.xcworkspace` for Xcode workspaces
 - `Package.swift` for Swift packages
 - `Project.swift` for Tuist projects
-- `Dependencies.swift` for Tuist projects with [external dependencies](https://docs.old.tuist.io/guides/third-party-dependencies)
+- Tuist with [external dependencies](https://docs.tuist.dev/en/guides/features/projects/dependencies#external-dependencies)
+    - Tuist 4.x: `swift-package-list Package.swift --custom-source-packages-path .build` (in the `Tuist` folder)
+    - Tuist 3.x: `swift-package-list Dependencies.swift` 
 
 In addition to that you can specify the following options:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ brew install swift-package-list
 mint install FelixHerrmann/swift-package-list
 ```
 
+#### Using [Mise](https://mise.jdx.dev/dev-tools/backends/spm.html)
+
+```shell
+mise use spm:tuist/tuist
+```
+
 #### Installing from source:
 
 Clone or download this repository and run `make install`, `make update` or `make uninstall`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ mint install FelixHerrmann/swift-package-list
 #### Using [Mise](https://mise.jdx.dev/dev-tools/backends/spm.html)
 
 ```shell
-mise use spm:tuist/tuist
+mise use spm:FelixHerrmann/swift-package-list
 ```
 
 #### Installing from source:


### PR DESCRIPTION
I wanted to use this tool in our Tuist project (on Tuist 4), and found a couple of issues mentioning this:

1. https://github.com/FelixHerrmann/swift-package-list/issues/111
2. https://github.com/FelixHerrmann/swift-package-list/issues/112

And I thought it would be nice to have this reflected in the readme so others can find it easily without searching through GitHub issues.

Also, I thought it would be nice to make it clear that the tool can be installed via Mise (which most Tuist users use).

Hope you can approve it @FelixHerrmann, or let me know if something should be changed.

Thanks for a great tool!